### PR TITLE
Remove system76/proposed PPA before Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 install:
  - docker pull elementary/docker:juno-unstable
- - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && meson build --prefix=/usr && cd build && ninja"
+ - docker run -v "$PWD":/tmp/build-dir elementary/docker:juno-unstable /bin/sh -c "add-apt-repository --remove ppa:system76/proposed && apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd /tmp/build-dir && meson build --prefix=/usr && cd build && ninja"
 
 script:
  - echo BUILDS PASSED


### PR DESCRIPTION
This PR should replace #99 to get builds passing in Travis by removing the `system76/proposed` PPA which breaks some of the dependency graph.

Long story short, the `system76/proposed` version of `libgl1-mesa-dri` depends on `libllvm7` which is a package only available in the `system76/pop` PPA, which is not installed in the docker image. Rather than adding another system76 PPA, removing it as a dependency for the Travis build is proposed in this PR