### PR TITLE
Fix output layout to match old style and other panel

### DIFF
--- a/src/OutputPanel.vala
+++ b/src/OutputPanel.vala
@@ -114,8 +114,8 @@ public class Sound.OutputPanel : Gtk.Grid {
         no_device_grid.show_all ();
         devices_listbox.set_placeholder (no_device_grid);
 
-        attach (available_label, 0, 0, 3, 1);
-        attach (devices_frame, 0, 1, 3, 1);
+        attach (available_label, 0, 0, 4, 1);
+        attach (devices_frame, 0, 1, 4, 1);
         attach (ports_label, 0, 2);
         attach (ports_dropdown, 1, 2, 2);
         attach (volume_label, 0, 3);
@@ -264,3 +264,4 @@ public class Sound.OutputPanel : Gtk.Grid {
         });
     }
 }
+


### PR DESCRIPTION
Fixes an issue raised here which happened in master: https://github.com/elementary/switchboard-plug-sound/pull/83#pullrequestreview-184838013

## Old

![screenshot from 2019-01-03 12 48 35 2x](https://user-images.githubusercontent.com/611168/50655472-ee876c00-0f55-11e9-8a4d-81669c100493.png)

## New

![screenshot from 2019-01-03 12 48 05 2x](https://user-images.githubusercontent.com/611168/50655476-f2b38980-0f55-11e9-9744-6f735d6c63d9.png)
