### PR TITLE
Fix crash when pulseaudio module-echo-cancel is loaded.

### DIFF
--- a/data/sound.appdata.xml.in
+++ b/data/sound.appdata.xml.in
@@ -7,6 +7,15 @@
   <icon type="stock">preferences-desktop-sound</icon>
   <translation type="gettext">sound-plug</translation>
   <releases>
+    <release version="2.2.5" date="2020-07-07" urgency="medium">
+      <description>
+        <p>Minor updates:</p>
+        <ul>
+          <li>Fix crash with PulseAudio's echo cancellation plugin</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.2.4" date="2020-05-28" urgency="medium">
       <description>
         <p>Minor updates:</p>

--- a/src/Device.vala
+++ b/src/Device.vala
@@ -106,10 +106,12 @@ public class Sound.Device : GLib.Object {
         }
     }
 
-    public string? get_matching_profile (Device other_device) {
-        foreach (var profile in profiles) {
-            if (other_device.profiles.contains (profile)) {
-                return profile;
+    public string? get_matching_profile (Device? other_device) {
+        if (other_device != null) {
+            foreach (var profile in profiles) {
+                if (other_device.profiles.contains (profile)) {
+                    return profile;
+                }
             }
         }
 

--- a/src/InputPanel.vala
+++ b/src/InputPanel.vala
@@ -28,7 +28,7 @@ public class Sound.InputPanel : Gtk.Grid {
     Gtk.Switch volume_switch;
     Gtk.LevelBar level_bar;
 
-    private Device default_device;
+    private Device? default_device = null;
     private InputDeviceMonitor device_monitor;
 
     construct {

--- a/src/PulseAudioManager.vala
+++ b/src/PulseAudioManager.vala
@@ -453,8 +453,8 @@ public class Sound.PulseAudioManager : GLib.Object {
                 device.card_source_index = (int)source.index;
                 device.card_source_name = source.name;
                 debug ("\t\t\tdevice.card_source_name: %s", device.card_source_name);
-                device.card_source_port_name = source.active_port.name;
-                if (device.port_name == source.active_port.name) {
+                if (source.active_port != null && device.port_name == source.active_port.name) {
+                    device.card_source_port_name = source.active_port.name;
                     device.source_name = source.name;
                     debug ("\t\t\tdevice.source_name: %s", device.card_source_name);
                     device.source_index = (int)source.index;
@@ -504,12 +504,18 @@ public class Sound.PulseAudioManager : GLib.Object {
 
         debug ("\t\tcard: %u", sink.card);
         if (debug_enabled) {
+            // Assuming that if sink.active_port is null, then sink.ports is empty
             foreach (var port in sink.ports) {
                 debug ("\t\tport: %s (%s)", port.description, port.name);
             }
         }
 
-        debug ("\t\tactive port: %s (%s)", sink.active_port.description, sink.active_port.name);
+
+        if (sink.active_port != null) {
+            debug ("\t\tactive port: %s (%s)", sink.active_port.description, sink.active_port.name);
+        } else {
+            warning ("Sink %s has no active port", sink.name);
+        }
 
         foreach (var device in output_devices.values) {
             if (device.card_index == sink.card) {
@@ -517,8 +523,9 @@ public class Sound.PulseAudioManager : GLib.Object {
                 device.card_sink_index = (int)sink.index;
                 device.card_sink_name = sink.name;
                 debug ("\t\t\tdevice.card_sink_name: %s", device.card_sink_name);
-                device.card_sink_port_name = sink.active_port.name;
-                if (device.port_name == sink.active_port.name) {
+
+                if (sink.active_port != null && device.port_name == sink.active_port.name) {
+                    device.card_sink_port_name = sink.active_port.name;
                     device.sink_name = sink.name;
                     debug ("\t\t\tdevice.sink_name: %s", device.card_sink_name);
                     device.sink_index = (int)sink.index;

--- a/src/PulseAudioManager.vala
+++ b/src/PulseAudioManager.vala
@@ -83,6 +83,7 @@ public class Sound.PulseAudioManager : GLib.Object {
         // the profile has to be switched from analog stereo to digital stereo.
         // Attempt to find profiles that support both selected input and output
         var other_device = device.input? default_output : default_input;
+
         var profile_name = device.get_matching_profile (other_device);
         // otherwise fall back to supporting this device only
         if (profile_name == null) {
@@ -207,7 +208,11 @@ public class Sound.PulseAudioManager : GLib.Object {
         yield;
     }
 
-    public void change_device_mute (Device device, bool mute = true) {
+    public void change_device_mute (Device? device, bool mute = true) {
+        if (device == null) {
+            return;
+        }
+
         if (device.input) {
             context.set_source_mute_by_name (device.source_name, mute, null);
         } else {
@@ -215,7 +220,11 @@ public class Sound.PulseAudioManager : GLib.Object {
         }
     }
 
-    public void change_device_volume (Device device, double volume) {
+    public void change_device_volume (Device? device, double volume) {
+        if (device == null) {
+            return;
+        }
+
         device.volume_operations.foreach ((operation) => {
             if (operation.get_state () == PulseAudio.Operation.State.RUNNING) {
                 operation.cancel ();
@@ -239,7 +248,11 @@ public class Sound.PulseAudioManager : GLib.Object {
         }
     }
 
-    public void change_device_balance (Device device, float balance) {
+    public void change_device_balance (Device? device, float balance) {
+        if (device == null) {
+            return;
+        }
+
         var cvol = device.cvolume;
         cvol = cvol.set_balance (device.channel_map, balance);
         PulseAudio.Operation? operation = null;
@@ -513,8 +526,6 @@ public class Sound.PulseAudioManager : GLib.Object {
 
         if (sink.active_port != null) {
             debug ("\t\tactive port: %s (%s)", sink.active_port.description, sink.active_port.name);
-        } else {
-            warning ("Sink %s has no active port", sink.name);
         }
 
         foreach (var device in output_devices.values) {


### PR DESCRIPTION
Fixes #122 

When the PulseAudio echo cancel module is installed, a sink with no ports is produced, requiring some extra null checks in PulseAudioManager.vala and elsewhere.

Some additional explicit null checks are included to avoid terminal warnings, although these are not required to prevent a crash.