### PR TITLE
InputPanel: slow down monitor level decay

### DIFF
--- a/src/InputPanel.vala
+++ b/src/InputPanel.vala
@@ -12,6 +12,7 @@ public class Sound.InputPanel : Gtk.Box {
     private Gtk.Scale volume_scale;
     private Gtk.Switch volume_switch;
     private InputDeviceMonitor device_monitor;
+    private uint monitor_timeout_id = 0;
     private unowned PulseAudioManager pam;
 
     construct {
@@ -80,7 +81,16 @@ public class Sound.InputPanel : Gtk.Box {
 
         device_monitor = new InputDeviceMonitor ();
         device_monitor.update_fraction.connect ((fraction) => {
-            level_bar.value = fraction;
+            if (fraction >= level_bar.value) {
+                level_bar.value = fraction;
+                return;
+            }
+
+            monitor_timeout_id = Timeout.add (1, () => {
+                level_bar.value = level_bar.value * 0.95;
+                monitor_timeout_id = 0;
+                return Source.REMOVE;
+            });
         });
 
         pam = PulseAudioManager.get_default ();


### PR DESCRIPTION
This is kind of an experiment to try to make the levelbar more obviously useful. I'm operating off of the idea that the main use of the levelbar is in watching out for clipping and you'll want the slider to be as high as possible without clipping. Having the levelbar more slowly shrink rather than bounce around to exact input values should highlight those peaks more.

I'm not sure though if that feels good and right or if it just feels like it's not responding correctly? Drafting for feedback