### PR TITLE
OutputPanel: Use C_ instead of NC_

### DIFF
--- a/src/OutputPanel.vala
+++ b/src/OutputPanel.vala
@@ -80,11 +80,11 @@ public class Sound.OutputPanel : Gtk.Box {
         balance_scale.adjustment.page_increment = 0.1;
 
         /// TRANSLATORS: describes sound balance
-        balance_scale.add_mark (-1, Gtk.PositionType.BOTTOM, NC_("balance", "Left"));
+        balance_scale.add_mark (-1, Gtk.PositionType.BOTTOM, C_("balance", "Left"));
         /// TRANSLATORS: describes sound balance
-        balance_scale.add_mark (0, Gtk.PositionType.BOTTOM, NC_("balance", "Center"));
+        balance_scale.add_mark (0, Gtk.PositionType.BOTTOM, C_("balance", "Center"));
         /// TRANSLATORS: describes sound balance
-        balance_scale.add_mark (1, Gtk.PositionType.BOTTOM, NC_("balance", "Right"));
+        balance_scale.add_mark (1, Gtk.PositionType.BOTTOM, C_("balance", "Right"));
 
         var alerts_label = new Granite.HeaderLabel (_("Event Alerts")) {
             secondary_text = _("Notify when the system can't do something in response to input, like attempting to backspace in an empty input or switch windows when only one is open.")


### PR DESCRIPTION
`NC_` is for adding context for const strings like this:

```vala
const string FOO = NC_("context", "Foo");

warning ("Do %s", _(FOO));
```

So we should use `C_` instead, otherwise these strings won't shown as translated.