### PR TITLE
AppRow: Fix default toggle position

### DIFF
--- a/src/AppRow.vala
+++ b/src/AppRow.vala
@@ -83,6 +83,7 @@ public class Sound.AppRow : Gtk.Grid {
         media_name_label.label = media_name_label.tooltip_text = app.media_name;
         volume_scale.set_value (app.volume);
         mute_switch.state = !app.muted;
+        mute_switch.active = !app.muted;
         volume_scale.sensitive = !app.muted;
 
         if (app.muted) {


### PR DESCRIPTION
A simple fix for default toggle position when an application is not muted.

Before: 
<img width="761" height="710" alt="image" src="https://github.com/user-attachments/assets/5748c397-2bbd-40d9-baf2-b936a06d996c" />

After:
<img width="818" height="751" alt="image" src="https://github.com/user-attachments/assets/8e928485-67e6-4c95-a858-913be51d8e21" />
