### PR TITLE
Fix volume adjust crash

### DIFF
--- a/src/PulseAudioManager.vala
+++ b/src/PulseAudioManager.vala
@@ -594,10 +594,6 @@ public class Sound.PulseAudioManager : GLib.Object {
                         default_output = device;
                     }
 
-                } else {
-                    device.sink_name = null;
-                    device.sink_index = -1;
-                    device.is_default = false;
                 }
             }
         }


### PR DESCRIPTION
Device sink name was null.
This is on Asus Zenbook S14 intel panther lake laptop running OS9 daily with mainline kernel 7.2 to enable sound hardware working.